### PR TITLE
fix: restore `updateFriends` bridge export on iOS and Android

### DIFF
--- a/android/src/main/java/com/openimsdkrn/OpenImSdkRnModule.java
+++ b/android/src/main/java/com/openimsdkrn/OpenImSdkRnModule.java
@@ -765,6 +765,7 @@ public class OpenImSdkRnModule extends ReactContextBaseJavaModule {
     Open_im_sdk.addFriend(new BaseImpl(promise), operationID, map2string(params));
   }
 
+  @ReactMethod
   public void updateFriends(ReadableMap params, String operationID, Promise promise) {
     Open_im_sdk.updateFriends(new BaseImpl(promise), operationID, map2string(params));
   }

--- a/ios/OpenImSdkRn.m
+++ b/ios/OpenImSdkRn.m
@@ -881,6 +881,11 @@ RCT_EXPORT_METHOD(addFriend:(NSDictionary *)paramsReq operationID:(NSString *)op
     Open_im_sdkAddFriend(proxy, operationID, paramsReqJson);
 }
 
+RCT_EXPORT_METHOD(updateFriends:(NSDictionary *)params operationID:(NSString *)operationID resolver:(RCTPromiseResolveBlock)resolver rejecter:(RCTPromiseRejectBlock)rejecter) {
+    RNCallbackProxy *proxy = [[RNCallbackProxy alloc] initWithCallback:resolver rejecter:rejecter];
+    Open_im_sdkUpdateFriends(proxy, operationID, [params json]);
+}
+
 RCT_EXPORT_METHOD(setFriendRemark:(NSDictionary *)options operationID:(NSString *)operationID resolver:(RCTPromiseResolveBlock)resolver rejecter:(RCTPromiseRejectBlock)rejecter) {
     RNCallbackProxy *proxy = [[RNCallbackProxy alloc] initWithCallback:resolver rejecter:rejecter];
   

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -99,8 +99,8 @@ export declare type GetSpecifiedFriendsParams = {
 export type UpdateFriendsParams = {
   friendUserIDs: string[];
   isPinned?: boolean;
-  remark?: boolean;
-  ex?: boolean;
+  remark?: string;
+  ex?: string;
 };
 
 export type AccessFriendParams = {


### PR DESCRIPTION
- iOS: add missing `RCT_EXPORT_METHOD(updateFriends...)`
- Android: add missing `@ReactMethod` so `updateFriends` is exposed to React Native
- Fix incorrect TypeScript types for `updateFriends` parameters
