### PR TITLE
fix: fix `networkStatusChanged` and `hideAllConversations` bridge name mismatch

### DIFF
--- a/android/src/main/java/com/openimsdkrn/OpenImSdkRnModule.java
+++ b/android/src/main/java/com/openimsdkrn/OpenImSdkRnModule.java
@@ -111,7 +111,7 @@ public class OpenImSdkRnModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void networkStatusChange(String operationID, Promise promise) {
+  public void networkStatusChanged(String operationID, Promise promise) {
     Open_im_sdk.networkStatusChanged(new BaseImpl(promise), operationID);
   }
 

--- a/ios/OpenImSdkRn.m
+++ b/ios/OpenImSdkRn.m
@@ -191,7 +191,7 @@ RCT_EXPORT_METHOD(setAppBackgroundStatus:(BOOL)isBackground operationID:(NSStrin
     Open_im_sdkSetAppBackgroundStatus(proxy, operationID, isBackground);
 }
 
-RCT_EXPORT_METHOD(networkStatusChange:(NSString *)operationID resolver:(RCTPromiseResolveBlock)resolver rejecter:(RCTPromiseRejectBlock)rejecter) {
+RCT_EXPORT_METHOD(networkStatusChanged:(NSString *)operationID resolver:(RCTPromiseResolveBlock)resolver rejecter:(RCTPromiseRejectBlock)rejecter) {
     RNCallbackProxy *proxy = [[RNCallbackProxy alloc] initWithCallback:resolver rejecter:rejecter];
     Open_im_sdkNetworkStatusChanged(proxy, operationID);
 }
@@ -275,12 +275,12 @@ RCT_EXPORT_METHOD(setGlobalRecvMessageOpt:(NSInteger)opt operationID:(NSString *
     Open_im_sdkSetSelfInfo(proxy, operationID, [param json]);
 }
 
-RCT_EXPORT_METHOD(hideAllConversations:(NSString *)operationID  resolver:(RCTPromiseResolveBlock)resolver rejecter:(RCTPromiseRejectBlock)rejecter) {
+RCT_EXPORT_METHOD(hideAllConversations:(NSString *)operationID resolver:(RCTPromiseResolveBlock)resolver rejecter:(RCTPromiseRejectBlock)rejecter) {
     RNCallbackProxy *proxy = [[RNCallbackProxy alloc] initWithCallback:resolver rejecter:rejecter];
     Open_im_sdkHideAllConversations(proxy, operationID);
 }
 
-RCT_EXPORT_METHOD(hideConversation:(NSString *)conversationID operationID:(NSString *)operationID  resolver:(RCTPromiseResolveBlock)resolver rejecter:(RCTPromiseRejectBlock)rejecter) {
+RCT_EXPORT_METHOD(hideConversation:(NSString *)conversationID operationID:(NSString *)operationID resolver:(RCTPromiseResolveBlock)resolver rejecter:(RCTPromiseRejectBlock)rejecter) {
     RNCallbackProxy *proxy = [[RNCallbackProxy alloc] initWithCallback:resolver rejecter:rejecter];
     Open_im_sdkHideConversation(proxy, operationID, conversationID);
 }

--- a/src/OpenIMSDK.native.ts
+++ b/src/OpenIMSDK.native.ts
@@ -357,7 +357,7 @@ export interface NativeOpenIMSDKInterface {
     operationID: string
   ) => Promise<unknown>;
   hideConversation: (conversationID: string, operationID: string) => Promise<unknown>;
-  hideAllConversation: (operationID: string) => Promise<unknown>;
+  hideAllConversations: (operationID: string) => Promise<unknown>;
   clearConversationAndDeleteAllMsg: (
     conversationID: string,
     operationID: string

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -454,8 +454,8 @@ class OpenIMSDK extends Emitter {
     return this.invoke(NativeOpenIMSDK.hideConversation, [conversationID, operationID]);
   }
 
-  hideAllConversation(operationID: string = id()) {
-    return this.invoke(NativeOpenIMSDK.hideAllConversation, [operationID]);
+  hideAllConversations(operationID: string = id()) {
+    return this.invoke(NativeOpenIMSDK.hideAllConversations, [operationID]);
   }
 
   clearConversationAndDeleteAllMsg(conversationID: string, operationID: string = id()) {


### PR DESCRIPTION
- rename iOS and Android bridge export from `networkStatusChange` to `networkStatusChanged`.
- align JS native interface and SDK call to use `hideAllConversations`.
