### PR TITLE
fix: align `findMessageList` params and return type across JS and native bridges

### DIFF
--- a/android/src/main/java/com/openimsdkrn/OpenImSdkRnModule.java
+++ b/android/src/main/java/com/openimsdkrn/OpenImSdkRnModule.java
@@ -610,8 +610,8 @@ public class OpenImSdkRnModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void findMessageList(ReadableMap findOptions, String operationID, Promise promise) {
-    Open_im_sdk.findMessageList(new BaseImpl(promise), operationID, map2string(findOptions));
+  public void findMessageList(ReadableArray findOptions, String operationID, Promise promise) {
+    Open_im_sdk.findMessageList(new BaseImpl(promise), operationID, findOptions.toString());
   }
 
   @ReactMethod

--- a/ios/OpenImSdkRn.m
+++ b/ios/OpenImSdkRn.m
@@ -704,7 +704,7 @@ RCT_EXPORT_METHOD(sendMessageNotOss:(NSDictionary *)options operationID:(NSStrin
     Open_im_sdkSendMessageNotOss(proxy, operationID, [message json], recvID, groupID, [offlinePushInfo json], isOnlineOnly);
 }
 
-RCT_EXPORT_METHOD(findMessageList:(NSDictionary *)findOptions operationID:(NSString *)operationID resolver:(RCTPromiseResolveBlock)resolver rejecter:(RCTPromiseRejectBlock)rejecter) {
+RCT_EXPORT_METHOD(findMessageList:(NSArray *)findOptions operationID:(NSString *)operationID resolver:(RCTPromiseResolveBlock)resolver rejecter:(RCTPromiseRejectBlock)rejecter) {
     RNCallbackProxy *proxy = [[RNCallbackProxy alloc] initWithCallback:resolver rejecter:rejecter];
     NSString *findOptionsJson = [findOptions json];
     

--- a/src/OpenIMSDK.native.ts
+++ b/src/OpenIMSDK.native.ts
@@ -484,7 +484,7 @@ export interface NativeOpenIMSDKInterface {
   findMessageList: (
     params: FindMessageParams[],
     operationID: string
-  ) => Promise<MessageItem[]>;
+  ) => Promise<SearchMessageResult>;
   insertGroupMessageToLocalStorage: (
     params: InsertGroupMsgParams,
     operationID: string


### PR DESCRIPTION
- iOS: change `findMessageList` bridge param type from `NSDictionary` to `NSArray`
- Android: change `findMessageList` bridge param type from `ReadableMap` to `ReadableArray`
- JS: fix `findMessageList` return type from `MessageItem[]` to `SearchMessageResult`
